### PR TITLE
Add MVI-Bench (ICML 2026) to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,3 +817,7 @@ Here, we've summarized existing LVLM Attack methods in our survey paper👍.
   * Youting Wang, Yuan Tang, Yitian Qian, Chen Zhao
   * Northeastern University, Carnegie Mellon University, Boston University, New York University
   * [Arxiv2026] https://arxiv.org/abs/2603.13385
+* **MVI-Bench: A Comprehensive Benchmark for Evaluating Robustness to Misleading Visual Inputs in LVLMs** | [Github](https://github.com/chenyil6/MVI-Bench)  #
+  * Huiyi Chen, Jiawei Peng, Dehai Min, Changchang Sun, Kaijie Chen, Yan Yan, Xu Yang, Lu Cheng
+  * UIUC, UIC, Southeast University
+  * [ICML2026] https://arxiv.org/abs/2511.14159


### PR DESCRIPTION
Adding **MVI-Bench** (ICML 2026) to the **Benchmarks** section.

While MVI-Bench is not strictly an adversarial *attack* (no optimization-based perturbations), it sits naturally alongside **AVIBench** — already in your Adversarial-Attack section — as a *robustness-evaluation* benchmark for visual inputs that mislead LVLMs. The Benchmarks section already includes related-but-not-strictly-attack works (Meme-Safety-Bench, VisualLeakBench).

MVI-Bench characterizes how **misleading visual inputs** undermine LVLM robustness, grounded in three hierarchical levels of visual primitives (Visual Concept / Visual Attribute / Visual Relationship), 6 categories, **1,248 expertly annotated VQA instances**, evaluated on **18 SOTA LVLMs**. Introduces **MVI-Sensitivity**, a fine-grained robustness metric.

- Paper: https://arxiv.org/abs/2511.14159
- Code:  https://github.com/chenyil6/MVI-Bench

If you'd prefer the entry not be added since it's not strictly an attack benchmark, totally understandable — feel free to close. Thanks for considering!